### PR TITLE
deploy topology as defined in the platform spec

### DIFF
--- a/.github/workflows/build-devel.yml
+++ b/.github/workflows/build-devel.yml
@@ -1,11 +1,12 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Build
+name: Build Devel Image
 on:
   push:
-    branches: 
-    - "main"
+    branches:
+     - "*"
+     - "!main" 
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -17,7 +18,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2.12
       with:
         image: nested-environment-builder
-        tags: latest ${{ github.sha }}
+        tags: ${{ github.sha }}
         dockerfiles: ./Containerfile
     # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
     # in which case 'username' and 'password' can be omitted.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Build
+on:
+  push:
+    branches: [ "SPLAT-1738" ]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2.12
+      with:
+        image: nested-environment-builder
+        tags: ${{ github.sha }}
+        dockerfiles: ./Containerfile
+
+    # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
+    # in which case 'username' and 'password' can be omitted.
+    - name: Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/ocp-splat
+        username: ocp-splat+splat_team_push
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/app/src
 
 RUN dnf install -y python jq git bind-utils unzip
 RUN python3 -m ensurepip --default-pip
-RUN pip3 install ansible pyvmomi --user
+RUN pip3 install ansible envsubst pyvmomi --user
 RUN pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
 ENV PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,17 +1,15 @@
-FROM registry.access.redhat.com/ubi9/ubi@sha256:b00d5990a00937bd1ef7f44547af6c7fd36e3fd410e2c89b5d2dfc1aff69fe99
+FROM registry.access.redhat.com/ubi8/python-311@sha256:ec2f4c89e18373c75a72f5b47da4d3ee826e8961a9c6a26ba2fd3112f5a41e4a
 
-WORKDIR /usr/app/src
+USER root
+RUN dnf install -y jq git bind-utils unzip
 
-RUN dnf install -y python jq git bind-utils unzip
-RUN python3 -m ensurepip --default-pip
-RUN pip3 install ansible envsubst pyvmomi --user
+USER default
+COPY . .
+
+RUN pip install ansible envsubst pyvmomi
 RUN pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
-ENV PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN curl -O -L https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
 RUN chmod +x yq_linux_amd64
-RUN mv yq_linux_amd64 /usr/local/bin/yq
-
-COPY . .
-
-CMD ./run-from-job.sh
+RUN mkdir -p /opt/app-root/src/.local/bin
+RUN mv yq_linux_amd64 /opt/app-root/src/.local/bin/yq

--- a/Containerfile
+++ b/Containerfile
@@ -2,10 +2,15 @@ FROM registry.access.redhat.com/ubi9/ubi@sha256:b00d5990a00937bd1ef7f44547af6c7f
 
 WORKDIR /usr/app/src
 
-RUN dnf install -y python
+RUN dnf install -y python jq git bind-utils unzip
 RUN python3 -m ensurepip --default-pip
-RUN pip3 install ansible --user
+RUN pip3 install ansible pyvmomi --user
+RUN pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
 ENV PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN curl -O -L https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+RUN chmod +x yq_linux_amd64
+RUN mv yq_linux_amd64 /usr/local/bin/yq
 
 COPY . .
 

--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ RUN chown -R default /usr/app
 USER default
 COPY . .
 
-RUN pip install ansible envsubst pyvmomi
+RUN pip install ansible envsubst pyvmomi envbash ansible-runner
 RUN pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
 
 RUN curl -O -L https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi9/ubi@sha256:b00d5990a00937bd1ef7f44547af6c7fd36e3fd410e2c89b5d2dfc1aff69fe99
+
+WORKDIR /usr/app/src
+
+RUN dnf install -y python
+RUN python3 -m ensurepip --default-pip
+RUN pip3 install ansible --user
+ENV PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+COPY . .
+
+CMD ./run-from-job.sh

--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,8 @@ FROM registry.access.redhat.com/ubi8/python-311@sha256:ec2f4c89e18373c75a72f5b47
 
 USER root
 RUN dnf install -y jq git bind-utils unzip
+RUN mkdir -p /usr/app
+RUN chown -R default /usr/app
 
 USER default
 COPY . .
@@ -13,3 +15,4 @@ RUN curl -O -L https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linu
 RUN chmod +x yq_linux_amd64
 RUN mkdir -p /opt/app-root/src/.local/bin
 RUN mv yq_linux_amd64 /opt/app-root/src/.local/bin/yq
+RUN ln -s /opt/app-root/src /usr/app

--- a/README.md
+++ b/README.md
@@ -1,23 +1,337 @@
 # nested-ova-ansible
-Create a dynamic vsphere setup (using DHCP)
 
-You will need a server to host your OVA files via http. I suggest miniserve (https://github.com/svenstaro/miniserve) or you could use some type of s3 bucket. You will also need a DHCP server on your network that you create your nested vSphere in.
+Provisions nested vCenter and ESXi hosts.
 
-I got my ESXi OVA from William Lam (https://williamlam.com/)
-I got my vCenter OVA from the vCenter install ISO (download from VMware/Broadcom)
+## Prerequisites
 
-Look at file runitall.sh for examples on how to run
+- Ansible
+- ESXi and vCenter OVAs hosted on an unauthenticated HTTP(S) server. For example: 
+    ```bash
+    python -m http.server
+    ```
+  or https://github.com/svenstaro/miniserve
+- DHCP server on the hosting environment port group
+- Set up your physical host to have your vSwitch or your DVS set to:
+    - [x] Promiscuous mode accept
+    - [x] MAC address changes accept
+    - [x] Forged transmits accept
+  Note: If using DVS 6.6+ set `MAC learning` Status to `ENABLED` (leave the defaults). Additionally, set `Forge Transmits` to `Accept`, `Promiscuous` to `Reject`, and `MAC address changes` to `Reject`.
+- If environment is deployed to a vSAN in the hosting vCenter:
+  ```bash
+  esxcli system settings advanced set -o /VSAN/FakeSCSIReservations -i 1
+  ```
+- [`platform.yaml`](https://github.com/openshift/api/blob/master/config/v1/types_infrastructure.go#L1360) which defines the topology to be deployed
 
-You will need to set up your physical host to have your vSwitch or your DVS set to:
-Promiscuous mode accept
-MAC address changes accept
-Forged transmits accept
+### Environment Variables
 
+- `GOVC_URL`                 - URL of the vCenter hosting the nested environment
+- `GOVC_USERNAME`            - Username of the account used to provision resources in the hosting environment
+- `GOVC_PASSWORD`            - Password of the account used to provision resources in the hosting environment
+- `GOVC_DATACENTER`          - Datacenter in the hosting environment where the nested environment will be deployed
+- `GOVC_DATASTORE`           - Datastore in the hosting environment where the nested environment will be deployed
+- `GOVC_CLUSTER`             - Cluster in the hosting environment where the nested environment will be deployed
+- `GOVC_NETWORK`             - Portgroup in the hosting environment where the nested environment will be deployed
+- `CLUSTER_NAME`             - Defines the prefix of the name of VMs associated with the nested environment
+- `NESTED_PASSWORD`          - the password applied to the accounts administrator@vsphere.local (vCenter) and root (ESXi)
+- `HOSTS_PER_FAILURE_DOMAIN` - optional: the number of hosts to deploy in each failure domain. default is 1
+- `VCPUS`                    - optional: the number of vCPUs assigned to the nested VMs. The resources required for the vCenter(s) are not to be included. The default is 24 vCPUs
+- `MEMORY`                   - optional: the amount of memory in GB assigned to the nested VMs. The resources required for the vCenter(s) are not to be included. The default is 96 GB
+- `DISKGB`                   - optional: the amount of disk space in GB assigned to the nested host local datastore. The resources required for the vCenter(s) are not to be included. The default is 1024 GB
 
-In a DVS 6.6+ you can setup MAC learning Status to ENABLED (leave the defaults). But you also need to set Forge Transmits to Accept. Promiscuous to Reject and MAC address changes to Reject.
+### Defining Media Assets
 
+Bespoke versions of vCenter and ESXi can deployed by defining elements in the `vc_assets` list in `group_vars/all.yml`. For example:
 
-Also if you are running on top of a vSAN don't forget this:  esxcli system settings advanced set -o /VSAN/FakeSCSIReservations -i 1
+```yaml
+vc_assets:
+- {
+  'name': 'VC7.0.3.01400-21477706-ESXi7.0u3q',
+  'esxiova': 'Nested_ESXi7.0u3q_Appliance_Template_v1.ova',
+  'vcenterova': 'VMware-vCenter-Server-Appliance-7.0.3.01400-21477706_OVF10.ova',
+  'httpova': "10.93.245.232:8080"
+}
+- {
+  'name': 'VC8.0.2.00100-22617221-ESXi8.0u2c', 
+  'esxiova': 'Nested_ESXi8.0u2c_Appliance_Template_v1.ova',
+  'vcenterova': 'VMware-vCenter-Server-Appliance-8.0.2.00100-22617221_OVF10.ova',
+  'httpova': "10.93.245.232:8080",
+  'default': "true"
+}
+```
 
+By default, the default asset will be chosen. If a specific version is created.
 
-PS. This code is a work in progress to have more features/options. So if you see stuff and wonder why is that there or remarked out. Debugging for new features and options in the future.
+### Defining Shared Datastores
+
+Shared NFS datastores can be attached to hosts by defining them in the `vc_nfs_shares` list in `group_vars/all.yml`. For example:
+
+```yaml
+vc_nfs_shares: 
+- {
+  "server": "161.26.99.159",
+  "name": "dsnested",
+  "path": "/DSW02SEV2284482_22/data01",
+  'type': 'nfs41', 
+  'nfs_ro': 'true',
+  'failure_domains': []
+}
+```
+
+By default, defined datastores are mounted to each host. If failure domains are defined, only hosts in those defined
+`failure_domains` will have the datastore mounted. `failure_domains` is an array of failure domains names.
+
+### Host Capacity Distribution
+
+`VCPUS` and `MEMORY` define the total resources to be used by _all_ of the deployed hosts. For example, if 4 hosts are deployed each host will receive (VCPUS / 4) vCPUs. 
+
+By default, only a single host is deployed per failure domain. If additional hosts are needed, the environment variable `HOSTS_PER_FAILURE_DOMAIN` can be configured to an integer which defines the number of hosts to create per failure domain.
+
+Practically, there should be a maximum of 4 hosts when using the default resource allocation. 
+
+## Running the tool
+
+```bash
+# Export variables
+export GOVC_URL=...
+export GOVC_USERNAME=...
+export GOVC_PASSWORD=...
+export GOVC_DATACENTER=...
+export GOVC_DATASTORE=...
+export GOVC_CLUSTER=...
+export GOVC_NETWORK=...
+export CLUSTER_NAME=...
+export MAINVCPASSWORD=...
+export HOSTS_PER_FAILURE_DOMAIN=...
+export VCPUS=...
+export MEMORY=...
+ansible-playbook -i hosts main_nested.yml --extra-var version="VC8.0.2.00100-22617221-ESXi8.0u2c"
+```
+
+Note: `version` is optional if there is a `default` asset defined.
+
+## Configuring Topology
+
+Topology is configured by parsing the same [platform spec](https://github.com/openshift/api/blob/master/config/v1/types_infrastructure.go#L1360) used by the machine API, infrastructure resource, and installer in OpenShift. This allows the deployment of complex topologies. The platform spec(`platform.yaml`), by default, is located in the same directory where ansible is run.
+
+We'll look at some common topologies. These examples are not exclusive.
+
+### Single Failure Domain
+
+Resource Allocation:
+- 24 vCPUs
+- 96 GB of RAM
+
+`platform.yaml`:
+```yaml
+platform:
+  vsphere:
+    vcenters:
+      - server: vcenter-1
+        datacenters:
+        - cidatacenter-nested-0
+    failureDomains:
+      - server: vcenter-1
+        name: "cidatacenter-nested-0-cicluster-nested-0"
+        zone: "cidatacenter-nested-0-cicluster-nested-0"
+        region: cidatacenter-nested-0
+        topology:
+          resourcePool: /cidatacenter-nested-0/host/cicluster-nested-0/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-0/host/cicluster-nested-0
+          datacenter: cidatacenter-nested-0
+          datastore: /cidatacenter-nested-0/datastore/dsnested
+          networks:
+            - "VM Network"
+```
+
+What does this provision?
+- [x] single vCenter
+    - [x] tag categories 
+    - [x] 1 datacenter
+        - [x] attach region tag
+        - [x] 1 cluster
+            - [x] attach zone tag
+            - [x] 1 resource pool
+            - [x] 1 ESXi host
+                - [x] 24 vCPUs
+                - [x] 96 GB RAM
+
+Note: The vCenter is deployed alongside the nested hosts, not within the nested hosts.
+
+### Two Failure Domains in Two Clusters
+
+Resource Allocation:
+- 24 vCPUs
+- 96 GB of RAM
+
+`platform.yaml`:
+```yaml
+platform:
+  vsphere:
+    vcenters:
+      - server: vcenter-1
+        datacenters:
+        - cidatacenter-nested-0
+    failureDomains:
+      - server: vcenter-1
+        name: "cidatacenter-nested-0-cicluster-nested-0"
+        zone: "cidatacenter-nested-0-cicluster-nested-0"
+        region: cidatacenter-nested-0
+        topology:
+          resourcePool: /cidatacenter-nested-0/host/cicluster-nested-0/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-0/host/cicluster-nested-0
+          datacenter: cidatacenter-nested-0
+          datastore: /cidatacenter-nested-0/datastore/dsnested
+          networks:
+            - "VM Network"
+      - server: vcenter-1
+        name: "cidatacenter-nested-0-cicluster-nested-1"
+        zone: "cidatacenter-nested-0-cicluster-nested-1"
+        region: cidatacenter-nested-0
+        topology:
+          resourcePool: /cidatacenter-nested-0/host/cicluster-nested-1/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-0/host/cicluster-nested-1
+          datacenter: cidatacenter-nested-0
+          datastore: /cidatacenter-nested-0/datastore/dsnested
+          networks:
+            - "VM Network"            
+```
+
+What does this provision?
+- [x] vCenter: vcenter-1
+    - [x] tag categories 
+    - [x] datacenter: cidatacenter-nested-0
+        - [x] attach region tag: cidatacenter-nested-0
+        - [x] cluster: cicluster-nested-0
+            - [x] attach zone tag: cidatacenter-nested-0-cicluster-nested-0
+            - [x] 1 resource pool: ipi-ci-clusters
+            - [x] 1 ESXi host
+                - [x] 12 vCPUs
+                - [x] 48 GB RAM
+                - [x] Attach NFS Datastore(s)
+        - [x] cluster: cicluster-nested-1
+            - [x] attach zone tag: cidatacenter-nested-0-cicluster-nested-1
+            - [x] 1 resource pool: ipi-ci-clusters
+            - [x] 1 ESXi host
+                - [x] 12 vCPUs
+                - [x] 48 GB RAM
+                - [x] Attach NFS Datastore(s)
+
+### Two vCenters with a Single Failure Domain in Each
+
+Resource Allocation:
+- 24 vCPUs
+- 96 GB of RAM
+
+`platform.yaml`:
+```yaml
+platform:
+  vsphere:
+    vcenters:
+      - server: vcenter-1
+        datacenters:
+        - cidatacenter-nested-0
+      - server: vcenter-2
+        datacenters:
+        - cidatacenter-nested-1    
+    failureDomains:
+      - server: vcenter-1
+        name: "cidatacenter-nested-0-cicluster-nested-0"
+        zone: "cidatacenter-nested-0-cicluster-nested-0"
+        region: cidatacenter-nested-0
+        topology:
+          resourcePool: /cidatacenter-nested-0/host/cicluster-nested-0/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-0/host/cicluster-nested-0
+          datacenter: cidatacenter-nested-0
+          datastore: /cidatacenter-nested-0/datastore/dsnested
+          networks:
+            - "VM Network"
+      - server: vcenter-2
+        name: "cidatacenter-nested-1-cicluster-nested-1"
+        zone: "cidatacenter-nested-1-cicluster-nested-1"
+        region: cidatacenter-nested-1
+        topology:
+          resourcePool: /cidatacenter-nested-1/host/cicluster-nested-1/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-1/host/cicluster-nested-1
+          datacenter: cidatacenter-nested-1
+          datastore: /cidatacenter-nested-1/datastore/dsnested
+          networks:
+            - "VM Network"            
+```
+
+What does this provision?
+- [x] vCenter: vcenter-1
+    - [x] tag categories 
+    - [x] datacenter: cidatacenter-nested-0
+        - [x] attach region tag: cidatacenter-nested-0
+        - [x] cluster: cicluster-nested-0
+            - [x] attach zone tag: cidatacenter-nested-0-cicluster-nested-0
+            - [x] 1 resource pool: ipi-ci-clusters
+            - [x] 1 ESXi host
+                - [x] 12 vCPUs
+                - [x] 48 GB RAM
+                - [x] Attach NFS Datastore(s)
+- [x] vCenter: vcenter-2
+    - [x] tag categories 
+    - [x] datacenter: cidatacenter-nested-1
+        - [x] attach region tag: cidatacenter-nested-1
+        - [x] cluster: cicluster-nested-1
+            - [x] attach zone tag: cidatacenter-nested-1-cicluster-nested-1
+            - [x] 1 resource pool: ipi-ci-clusters
+            - [x] 1 ESXi host
+                - [x] 12 vCPUs
+                - [x] 48 GB RAM
+                - [x] Attach NFS Datastore(s)
+
+### Failure Domain with HostGroup
+
+Resource Allocation:
+- 24 vCPUs
+- 96 GB of RAM
+
+`platform.yaml`:
+```yaml
+platform:
+  vsphere:
+    vcenters:
+      - server: vcenter-1
+        user: "administrator@vsphere.local"
+        password: "${vcenter_password}"
+        datacenters:
+        - cidatacenter-nested-0
+    failureDomains:
+      - server: vcenter-1
+        name: "cidatacenter-nested-0-cicluster-nested-0"
+        zone: "cidatacenter-nested-0-cicluster-nested-0"
+        region: cidatacenter-nested-0
+        zoneAffinity: "HostGroup"
+        topology:
+          resourcePool: /cidatacenter-nested-0/host/cicluster-nested-0/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-0/host/cicluster-nested-0
+          datacenter: cidatacenter-nested-0
+          datastore: /cidatacenter-nested-0/datastore/dsnested
+          networks:
+            - "VM Network"
+```
+
+What does this provision?
+- [x] vCenter: vcenter-1
+    - [x] tag categories 
+    - [x] datacenter: cidatacenter-nested-0
+        - [x] attach region tag: cidatacenter-nested-0
+        - [x] cluster: cicluster-nested-0
+        - [x] resource pool: ipi-ci-clusters
+        - [x] host group: cidatacenter-nested-0-cicluster-nested-0
+            - [x] 1 ESXi host
+            - [x] attach zone tag: cidatacenter-nested-0-cicluster-nested-0
+                - [x] 24 vCPUs
+                - [x] 96 GB RAM
+
+### Skip Tagging Failure Domain(s)
+
+Some configurations may dictate that tags not be attached to resources. For individual failiure domains, this can be done by preceding the zone or region name with a `-`. For example, `zone: "-cidatacenter-nested-0-cicluster-nested-0"` would result in the zone not being tagged for that failure domain.
+
+If tagging is to be completely disabled define the environment variable `SKIP_FAILURE_DOMAIN_TAGGING=true`.
+
+### Configuring Variables
+
+By default, no additional variables are required. However, if `/tmp/override-vars.yaml` is present, it will be loaded and will override defaults or allow undefined variables to be defined.

--- a/addhosts_vcenter.yml
+++ b/addhosts_vcenter.yml
@@ -26,7 +26,14 @@
         cluster_name: '{{ item.cluster }}'
       loop:
         - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }
-#        - { 'cluster': '{{ vc_fact_cluster2 }}', 'datacenter': '{{ vc_fact_datacenter2 }}' }
+    
+    - name: Create Resource Pool
+      community.vmware.vmware_resource_pool:
+        datacenter: '{{ item.datacenter }}'
+        cluster: '{{ item.cluster }}'
+        resource_pool: 'ipi-ci-clusters'
+      loop:
+        - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }
 
     - name: Enable DRS and set default VM behavior to fully automated
       community.vmware.vmware_cluster_drs:

--- a/addhosts_vcenter.yml
+++ b/addhosts_vcenter.yml
@@ -27,14 +27,6 @@
       loop:
         - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }
     
-    - name: Create Resource Pool
-      community.vmware.vmware_resource_pool:
-        datacenter: '{{ item.datacenter }}'
-        cluster: '{{ item.cluster }}'
-        resource_pool: 'ipi-ci-clusters'
-      loop:
-        - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }
-
     - name: Enable DRS and set default VM behavior to fully automated
       community.vmware.vmware_cluster_drs:
         datacenter: '{{ vc_fact_datacenter1 }}'
@@ -201,3 +193,16 @@
     datacenter: '{{ vc_fact_datacenter1 }}'
     cluster_name: '{{ vc_fact_cluster1 }}'
     allowed_datastores: "Datastore-{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
+
+- name: Create Resource Pool
+  community.vmware.vmware_resource_pool:
+    hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
+    password: "{{ vc_fact_password }}"
+    username: 'administrator@{{ vc_fact_domain }}'
+    validate_certs: false
+    datacenter: '{{ item.datacenter }}'
+    cluster: '{{ item.cluster }}'
+    resource_pool: 'ipi-ci-clusters'
+    state: present
+  loop:
+    - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }

--- a/addhosts_vcenter.yml
+++ b/addhosts_vcenter.yml
@@ -160,15 +160,17 @@
       ansible.builtin.debug:
         msg:
           - "{{ item }}"
-      loop: "{{ host_vmhbas['results'] }}"
+      loop: "{{ host_vmhbas['results'][0]['hosts_disk_info'] | list }}"
 
     - name: Create host datastore
       vars:
-        esxip: "{{ item['hosts_disk_info'] | list | first }}"
-        host_vmhba: "{{ item['hosts_disk_info'][esxip] }}"
-      when: "'hosts_disk_info' in item"
+        esxip: "{{ item }}"
+        host_vmhba: "{{ host_vmhbas['results'][0]['hosts_disk_info'][item] }}"
+      #when: "'hosts_disk_info' in item"
       ansible.builtin.include_tasks: create_datastore.yml
-      loop: "{{ host_vmhbas['results'] }}"
+      loop: "{{ host_vmhbas['results'][0]['hosts_disk_info'] | list }}"
+      loop_control:
+        index_var: hd_idx
 
     - name: Enable vMotion for Nested
       community.vmware.vmware_vmkernel:

--- a/addhosts_vcenter.yml
+++ b/addhosts_vcenter.yml
@@ -1,38 +1,60 @@
 ---
+- name: Configure topology
+  run_once: true
+  vars:
+    vcenter_failure_domains: []
+  block:
+    - name: Display vCenter facts
+      ansible.builtin.debug:
+        msg:
+          - "{{ vcenter }}"
 
-- name: List hosts in ESXi
-  ansible.builtin.debug:
-    msg: "Host: {{ item }}"
-  loop: "{{ groups['esxi'] }}"
+    - name: Get failure domains associated with the vCenter
+      ansible.builtin.set_fact:
+        vcenter_failure_domains: "{{ vcenter_failure_domains + [failure_domains_loop_var] }}"
+      when: "failure_domains_loop_var.server == vcenter"
+      loop: "{{ failure_domains }}"
+      loop_control:
+        loop_var: failure_domains_loop_var
 
-- name: List hosts in VC
-  ansible.builtin.debug:
-    msg: "Host: {{ item }}"
-  loop: "{{ groups['vc'] }}"
+    - name: Get datacenters associated with the vCenter
+      ansible.builtin.set_fact:
+        vcenter_datacenters: "{{ platform_spec_vcenters_loop_var.datacenters }}"
+      when: "platform_spec_vcenters_loop_var.server == vcenter"
+      loop: "{{ platform_spec.platform.vsphere.vcenters }}"
+      loop_control:
+        loop_var: platform_spec_vcenters_loop_var
 
-- name: Setup vsphere
+- name: Configure topology
+  run_once: true
+  module_defaults:
+    group/vmware:
+      hostname: "{{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
+      username: 'administrator@{{ vc_fact_domain }}'
+      password: "{{ vc_fact_password }}"
+      validate_certs: false
   block:
     - name: Create Datacenter
       community.vmware.vmware_datacenter:
         datacenter_name: '{{ item }}'
         state: present
-      loop:
-        - '{{ vc_fact_datacenter1 }}'
-#        - '{{ vc_fact_datacenter2 }}'
+      loop: "{{ vcenter_datacenters }}"
 
     - name: Create Cluster
       community.vmware.vmware_cluster:
-        datacenter_name: '{{ item.datacenter }}'
-        cluster_name: '{{ item.cluster }}'
-      loop:
-        - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }
-    
+        datacenter_name: '{{ item.topology.datacenter }}'
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
+
     - name: Enable DRS and set default VM behavior to fully automated
       community.vmware.vmware_cluster_drs:
-        datacenter: '{{ vc_fact_datacenter1 }}'
-        cluster_name: '{{ vc_fact_cluster1 }}'
         enable: true
         drs_default_vm_behavior: fullyAutomated
+        datacenter: '{{ item.topology.datacenter }}'
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
 
     - name: Set advs
       ansible.builtin.set_fact:
@@ -40,34 +62,58 @@
 
     - name: Enable HA without admission control
       community.vmware.vmware_cluster_ha:
-        datacenter: '{{ vc_fact_datacenter1 }}'
-        cluster_name: '{{ vc_fact_cluster1 }}'
+        datacenter: '{{ item.topology.datacenter }}'
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
         enable: true
         advanced_settings: "{{ advs }}"
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
 
+- name: Set up hosts
   run_once: true
+  vars:
+    host_vmhbas: []
+    hosts_in_vcenter: []
   module_defaults:
     group/vmware:
-      hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
+      hostname: "{{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
       username: 'administrator@{{ vc_fact_domain }}'
       password: "{{ vc_fact_password }}"
       validate_certs: false
-
-- name: Set up hosts
   block:
+    - name: "Build Host Slice to be added to vCenter"
+      ansible.builtin.set_fact:
+        hosts_in_vcenter: "{{ hosts_in_vcenter + [hostvars[groups['esxi'][fd_idx]].NESTEDVMIP] }}"
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
 
-    - name: "Add ESXi Host {{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }} to vCenter {{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
+    - name: "Build ESXi to vCenter Mapping"
+      ansible.builtin.set_fact:
+        vc_vcenter_host_map: "{{ vc_vcenter_host_map | default({}) | combine({vcenter: hosts_in_vcenter}) }}"
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
+
+    - name: "Add ESXi Host {{ hostvars[groups['esxi'][vcenter_idx]].NESTEDVMIP }} to vCenter {{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
       community.vmware.vmware_host:
-        datacenter: "{{ vc_fact_datacenter1 }}"
-        cluster: "{{ vc_fact_cluster1 }}"
+        datacenter: '{{ item.topology.datacenter }}'
+        cluster: '{{ item.topology.computeCluster.split("/")[-1] }}'
         esxi_username: "root"
         esxi_password: "{{ vc_fact_password }}"
+        esxi_hostname: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
         state: present
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
 
     - name: Set the Power Management Policy of all host systems from cluster to high-performance
       community.vmware.vmware_host_powermgmt_policy:
-        cluster_name: '{{ vc_fact_cluster1 }}'
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
         policy: high-performance
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
 
     - name: Update for system defaults config
       community.vmware.vmware_host_auto_start:
@@ -76,10 +122,20 @@
           start_delay: 100
           stop_action: guestShutdown
           wait_for_heartbeat: true
+        esxi_hostname: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
 
     - name: Get host facts
-      community.vmware.vmware_host_facts:
       register: host_facts
+      community.vmware.vmware_host_facts:
+        esxi_hostname: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
 
     - name: Display host facts
       ansible.builtin.debug:
@@ -88,121 +144,67 @@
 
     - name: Rescan HBA's for a given cluster - all found hosts will be scanned
       community.vmware.vmware_host_scanhba:
-        cluster_name: '{{ vc_fact_cluster1 }}'
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
         refresh_storage: true
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
 
-    - name: Gather info about vmhbas of an ESXi Host
+    - name: Gather info about vmhbas of hosts in the cluster
       community.vmware.vmware_host_disk_info:
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"
       register: host_vmhbas
 
-    - name: Set ip an ESXi Host
-      ansible.builtin.set_fact:
-        esxip: "{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
-
-    - name: Show esxi info
+    - name: Debug multi
       ansible.builtin.debug:
         msg:
-          - "{{ host_vmhbas.hosts_disk_info }}"
-          - "{{ esxip }}"
+          - "{{ item }}"
+      loop: "{{ host_vmhbas['results'] }}"
 
-    - name: Set disk esxi info
-      ansible.builtin.set_fact:
-        vmhbainfo: "{{ host_vmhbas['hosts_disk_info'][esxip] }}"
-
-    - name: Show vmhbainfo esxi
-      ansible.builtin.debug:
-        msg:
-          - "{{ vmhbainfo }}"
-
-    - name: Find disk by device_ctd
-      ansible.builtin.debug:
-        msg: "Disk {{ item.canonical_name }} matches vmhba0:C0:T2:L0"
-      loop: "{{ vmhbainfo }}"
-      when: item.device_ctd_list[0] == "vmhba0:C0:T2:L0"
-
-    - name: Set disk by device_ctd
-      ansible.builtin.set_fact:
-        vmfs_dn: "{{ item.canonical_name }}"
-      loop: "{{ vmhbainfo }}"
-      when: item.device_ctd_list[0] == "vmhba0:C0:T2:L0"
-
-    - name: Show vmfs dn
-      ansible.builtin.debug:
-        msg:
-          - "{{ vmfs_dn }}"
-
-    - name: Create datastore
-      community.vmware.vmware_host_datastore:
-        validate_certs: false
-        datastore_name: "Datastore-{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
-        vmfs_device_name: "{{ vmfs_dn }}"
-        vmfs_version: 6
-        datastore_type: vmfs
-        state: present
-
-    - name: Include vars nfs
-      ansible.builtin.include_vars:
-        file: nfshostip.yml
-      when: nfsetup | bool
-
-    - name: Mount NFS datastores to NESTED ESXi
-      community.vmware.vmware_host_datastore:
-        datastore_name: '{{ item.name }}'
-        datastore_type: '{{ item.type }}'
-        nfs_server: '{{ item.server }}'
-        nfs_path: '{{ item.path }}'
-        nfs_ro: '{{ item.nfs_ro }}'
-        state: present
-        validate_certs: false
-      loop:
-        - { 'name': '{{ nfsname }}', 'server': '{{ nfserver }}', 'path': '{{ sharepoint }}', 'type': 'nfs41', 'nfs_ro': 'true'}
-        - { 'name': '{{ nfsname2 }}', 'server': '{{ nfserver2 }}', 'path': '{{ sharepoint2 }}', 'type': 'nfs41', 'nfs_ro': 'false'}
-      when: nfsetup | bool
+    - name: Create host datastore
+      vars:
+        esxip: "{{ item['hosts_disk_info'] | list | first }}"
+        host_vmhba: "{{ item['hosts_disk_info'][esxip] }}"
+      when: "'hosts_disk_info' in item"
+      ansible.builtin.include_tasks: create_datastore.yml
+      loop: "{{ host_vmhbas['results'] }}"
 
     - name: Enable vMotion for Nested
       community.vmware.vmware_vmkernel:
         vswitch_name: vSwitch0
         portgroup_name: "Management Network"
         enable_vmotion: true
+        esxi_hostname: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
         enable_mgmt: true
         device: vmk0
         network:
           type: 'dhcp'
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
 
     - name: Exit Maintenance Mode
       community.vmware.vmware_maintenancemode:
         timeout: 3600
+        esxi_hostname: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
         state: absent
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
 
-  ignore_errors: true
-  module_defaults:
-    group/vmware:
-      hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
-      username: 'administrator@{{ vc_fact_domain }}'
-      password: "{{ vc_fact_password }}"
-      esxi_hostname: "{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
-      validate_certs: false
+      loop_control:
+        index_var: fd_idx
 
-
-- name: Set Allowed vCLS Datastores
-  community.vmware.vmware_cluster_vcls:
-    hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
-    password: "{{ vc_fact_password }}"
-    username: 'administrator@{{ vc_fact_domain }}'
-    validate_certs: false
-    datacenter: '{{ vc_fact_datacenter1 }}'
-    cluster_name: '{{ vc_fact_cluster1 }}'
-    allowed_datastores: "Datastore-{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
-
-- name: Create Resource Pool
-  community.vmware.vmware_resource_pool:
-    hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
-    password: "{{ vc_fact_password }}"
-    username: 'administrator@{{ vc_fact_domain }}'
-    validate_certs: false
-    datacenter: '{{ item.datacenter }}'
-    cluster: '{{ item.cluster }}'
-    resource_pool: 'ipi-ci-clusters'
-    state: present
-  loop:
-    - { 'cluster': '{{ vc_fact_cluster1 }}', 'datacenter': '{{ vc_fact_datacenter1 }}' }
+    - name: Create Resource Pool
+      community.vmware.vmware_resource_pool:
+        hostname: "{{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
+        password: "{{ vc_fact_password }}"
+        username: 'administrator@{{ vc_fact_domain }}'
+        validate_certs: false
+        datacenter: '{{ item.topology.datacenter }}'
+        cluster: '{{ item.topology.computeCluster.split("/")[-1] }}'
+        resource_pool: 'ipi-ci-clusters'
+        state: present
+      when: "item.server == vcenter"
+      loop: "{{ vcenter_failure_domains }}"

--- a/create_datastore.yml
+++ b/create_datastore.yml
@@ -50,7 +50,6 @@
         datastore_type: '{{ nfs_loop_var.type }}'
         nfs_server: '{{ nfs_loop_var.server }}'
         nfs_path: '{{ nfs_loop_var.path }}'
-        nfs_ro: '{{ nfs_loop_var.nfs_ro }}'
         state: present
         username: root
         validate_certs: false

--- a/create_datastore.yml
+++ b/create_datastore.yml
@@ -1,0 +1,59 @@
+---
+- name: Isolate host in host_disk_info
+  ansible.builtin.debug:
+    msg:
+      - "{{ host_vmhba }}"
+
+- name: Configure host datastore
+  run_once: true
+  module_defaults:
+    group/vmware:
+      hostname: "{{ esxip }}"
+      username: 'administrator@{{ vc_fact_domain }}'
+      password: "{{ vc_fact_password }}"
+      validate_certs: false
+  block:
+    - name: Find disk by device_ctd
+      ansible.builtin.debug:
+        msg: "Disk {{ host_vmhba_loop_var.canonical_name }} matches vmhba0:C0:T2:L0"
+      loop: "{{ host_vmhba }}"
+      loop_control:
+        loop_var: host_vmhba_loop_var
+      when: host_vmhba_loop_var.device_ctd_list[0] == "vmhba0:C0:T2:L0"
+
+    - name: Set disk by device_ctd
+      ansible.builtin.set_fact:
+        vmfs_dn: "{{ host_vmhba_loop_var.canonical_name }}"
+      loop: "{{ host_vmhba }}"
+      loop_control:
+        loop_var: host_vmhba_loop_var
+      when: host_vmhba_loop_var.device_ctd_list[0] == "vmhba0:C0:T2:L0"
+
+    - name: Show vmfs dn
+      ansible.builtin.debug:
+        msg:
+          - "{{ vmfs_dn }}"
+
+    - name: Create datastore
+      community.vmware.vmware_host_datastore:
+        validate_certs: false
+        username: root
+        datastore_name: "Datastore-{{ esxip }}"
+        vmfs_device_name: "{{ vmfs_dn }}"
+        vmfs_version: 6
+        datastore_type: vmfs
+        state: present
+
+    - name: Mount NFS datastores to NESTED ESXi
+      community.vmware.vmware_host_datastore:
+        datastore_name: '{{ nfs_loop_var.name }}'
+        datastore_type: '{{ nfs_loop_var.type }}'
+        nfs_server: '{{ nfs_loop_var.server }}'
+        nfs_path: '{{ nfs_loop_var.path }}'
+        nfs_ro: '{{ nfs_loop_var.nfs_ro }}'
+        state: present
+        username: root
+        validate_certs: false
+      loop: "{{ vc_nfs_shares }}"
+      loop_control:
+        loop_var: nfs_loop_var

--- a/dvs_hosts_vcenter.yml
+++ b/dvs_hosts_vcenter.yml
@@ -1,33 +1,56 @@
 ---
-
-- name: Set datacenter
-  ansible.builtin.set_fact:
-    vcdc: "{{ vc_fact_datacenter1 }}"
-
 - name: "Create dvSwitch"
+  module_defaults:
+    group/vmware:
+      hostname: "{{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
+      username: 'administrator@{{ vc_fact_domain }}'
+      password: "{{ vc_fact_password }}"
+      validate_certs: false
   block:
+    - name: Get vCenter index in platform spec
+      ansible.builtin.set_fact:
+        vcenter_datacenters: "{{ platform_spec_vcenters_loop_var.datacenters }}"
+      when: "platform_spec_vcenters_loop_var.server == vcenter"
+      loop: "{{ platform_spec.platform.vsphere.vcenters }}"
+      loop_control:
+        loop_var: platform_spec_vcenters_loop_var
 
-    - name: "Create dvSwitch {{ vcdc }}"
+    - name: "Create dvSwitch"
       community.vmware.vmware_dvswitch:
-        datacenter: "{{ vcdc }}"
-        switch: "dvSwitch-nested"
+        datacenter: "{{ dc_loop_var }}"
+        switch: "dvSwitch-nested-{{ dc_loop_var }}"
         version: 6.6.0
         mtu: 9000
         uplink_quantity: 1
         state: present
       run_once: true
+      loop: "{{ vcenter_datacenters }}"
+      loop_control:
+        loop_var: "dc_loop_var"
 
     - name: Time out to process
       ansible.builtin.pause:
         seconds: 10
 
+    - name: Get hosts in vCenter
+      ansible.builtin.set_fact:
+        vcenter_hosts: "{{ vc_vcenter_host_map[vcenter] | list }}"
+
+    - name: Hosts associated with vCenter
+      ansible.builtin.debug:
+        msg: "{{ vcenter_hosts }}"
+
     - name: "Add Host to dVS dvSwitch-nested"
       community.vmware.vmware_dvs_host:
-        esxi_hostname: "{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
-        switch_name: "dvSwitch-nested"
+        esxi_hostname: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
+        switch_name: "dvSwitch-nested-{{ item.topology.datacenter }}"
         vmnics:
           - vmnic1
         state: present
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: "fd_idx"
 
     - name: Time out to process
       ansible.builtin.pause:
@@ -36,15 +59,12 @@
     - name: Create no-vlan portgroup
       community.vmware.vmware_dvs_portgroup:
         portgroup_name: "{{ vc_fact_deployment_network }}"
-        switch_name: "dvSwitch-nested"
+        switch_name: "dvSwitch-nested-{{ item.topology.datacenter }}"
         vlan_id: 0
         num_ports: 120
         port_binding: static
         state: present
-
-  module_defaults:
-    group/vmware:
-      hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
-      username: 'administrator@{{ vc_fact_domain }}'
-      password: "{{ vc_fact_password }}"
-      validate_certs: false
+      when: "item.server == vcenter"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: "fd_idx"

--- a/dvs_hosts_vcenter.yml
+++ b/dvs_hosts_vcenter.yml
@@ -35,7 +35,7 @@
 
     - name: Create no-vlan portgroup
       community.vmware.vmware_dvs_portgroup:
-        portgroup_name: "{{ vc_fact_deployment_network2 }}"
+        portgroup_name: "{{ vc_fact_deployment_network }}"
         switch_name: "dvSwitch-nested"
         vlan_id: 0
         num_ports: 120

--- a/esxinested.yml
+++ b/esxinested.yml
@@ -57,7 +57,7 @@
         name: '{{ host_fact_hostname }}'
         enable_hidden_properties: true
         folder: "{{ vc_datacenter }}/vm/{{ vc_folder }}"
-        datastore: vsanDatastore
+        datastore: "{{ vc_datastore }}"
         disk_provisioning: thin
         networks:
           "VM Network": "{{ vc_fact_deployment_network }}"
@@ -74,7 +74,7 @@
         disk:
           - size_tb: 1
             type: thin
-            datastore: vsanDatastore
+            datastore: "{{ vc_datastore }}"
             state: present
             scsi_controller: 0
             unit_number: 2

--- a/esxinested.yml
+++ b/esxinested.yml
@@ -5,19 +5,17 @@
     msg: "Host: {{ item }}"
   loop: "{{ groups['esxi'] }}"
 
-- name: List hosts in VC
-  ansible.builtin.debug:
-    msg: "Host: {{ item }}"
-  loop: "{{ groups['vc'] }}"
-
 - name: Set esxi name
   ansible.builtin.set_fact:
     host_fact_hostname: "{{ hostvars[groups['esxi'][my_idx]].inventory_hostname }}"
 
 - name: ESXi Exists
   block:
+    - name: ESXi hardware
+      ansible.builtin.debug:
+        msg: "Memory: {{ esximemory }}MB - CPU: {{ esxicpu }}"
 
-    - name: "DELETE virtual machine {{ host_fact_hostname }} version {{ version }}"
+    - name: "DELETE virtual machine version"
       community.vmware.vmware_guest:
         datacenter: "{{ vc_datacenter }}"
         folder: "{{ vc_datacenter }}/vm/{{ vc_folder }}"
@@ -26,14 +24,14 @@
         force: true
       when: testingesxi | bool
 
-    - name: "Does ESXi virtual machine {{ host_fact_hostname }} exist"
+    - name: "Does ESXi virtual machine exist"
       community.vmware.vmware_guest:
         datacenter: "{{ vc_datacenter }}"
         folder: "{{ vc_datacenter }}/vm/{{ vc_folder }}"
         name: "{{ host_fact_hostname }}"
         state: present
 
-    - name: "Does ESXi virtual machine {{ host_fact_hostname }} exist get ip"
+    - name: "Does ESXi virtual machine exist get ip"
       community.vmware.vmware_guest_info:
         datacenter: "{{ vc_datacenter }}"
         name: "{{ host_fact_hostname }}"
@@ -49,8 +47,8 @@
         NESTEDVMIP: "{{ nested_vm.instance.guest.ipAddress }}"
 
   rescue:
-
-    - community.vmware.vmware_deploy_ovf:
+    - name: "Deploy ESXi VM"
+      community.vmware.vmware_deploy_ovf:
         url: "http://{{ httpova }}/{{ esxiova }}"
         power_on: false
         datacenter: "{{ vc_datacenter }}"
@@ -72,7 +70,7 @@
         datacenter: "{{ vc_datacenter }}"
         name: "{{ host_fact_hostname }}"
         disk:
-          - size_tb: 1
+          - size_gb: "{{ esxidisk }}"
             type: thin
             datastore: "{{ vc_datastore }}"
             state: present
@@ -137,6 +135,5 @@
   ansible.builtin.wait_for:
     host: "{{ hostvars[groups['esxi'][my_idx]].NESTEDVMIP }}"
     port: 443
-#    delay: 180
     sleep: 10
     timeout: 900

--- a/getcerts.yml
+++ b/getcerts.yml
@@ -36,11 +36,6 @@
     - name: Copy certs
       ansible.builtin.copy:
         src: "{{ item }}"
-        dest: /etc/pki/ca-trust/source/anchors
+        dest: "{{ lookup('ansible.builtin.env', 'SHARED_DIR') }}/additional_ca_cert.pem"
       with_fileglob:
-        - "/tmp/certs/lin/*"
-      become: true
-
-    - name: Update cert index
-      ansible.builtin.shell: update-ca-trust extract
-      become: true
+        - "/tmp/certs/lin/*.0"

--- a/getcerts.yml
+++ b/getcerts.yml
@@ -2,10 +2,9 @@
 
 - name: Get certs
   block:
-
     - name: Get certs
       ansible.builtin.get_url:
-        url: "https://{{ host_fact_name }}/certs/download.zip"
+        url: "https://{{ hostvars[vcenter].NESTEDVMIP }}/certs/download.zip"
         dest: /tmp/download.zip
         validate_certs: false
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -14,3 +14,43 @@ vc_password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
 vc_datacenter: "cidatacenter-2"
 vc_cluster: "cicluster-3"
 vc_folder: "nested"
+
+# defines tags to be associated with a region, which is a datacenter.
+vc_region_tags:
+ - us-east
+ - us-west
+
+# defines tags to be associated with a zone, which could be a compute
+# cluster or a host.
+vc_zone_tags:
+ - us-east-1
+ - us-east-2 
+ - us-west-1
+ - us-west-2
+
+# defines the association of tags to objects in the nested vCenter.
+# named tags and objects must exist. this merely defines the association.
+vc_tag_association:
+ -  {
+      tag: "us-east",
+      object_type: "Datacenter",
+      object_name: "nested-cidatacenter-1"
+    }
+
+# when defined, each of the tag names will be associated with 
+# a host. the list of tags is iterated and assigned to a given
+# host. the number of hosts and number of tags should be the same.
+vc_host_tags:
+ - us-east-1
+ - us-east-2
+
+# when defined, a host group will be created for each host group listed
+# below. a single host will be placed in each host group. The number of
+# hosts and host groups should be same.
+vc_host_groups:
+ cluster: nested-cicluster-1
+ datacenter: nested-cidatacenter-1
+ groups:
+  - host-group-1
+  - host-group-2
+   

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,18 +1,19 @@
 vc_fact_domain: "vsphere.local"
 vc_fact_ntp: "10.0.77.54"
-vc_fact_password: "{{ lookup('ansible.builtin.env', 'VCESXIPASSWORD') }}"
-vc_fact_datacenter1: "nested-cidatacenter-1"
-vc_fact_datacenter2: "nested-cidatacenter-2"
-vc_fact_cluster1: "nested-cicluster-1"
+vc_fact_password: "{{ lookup('ansible.builtin.env', 'NESTED_PASSWORD') }}"
+vc_fact_datacenter1: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
+
+vc_fact_datacenter2: "nested-cidatacenter"
+vc_fact_cluster1: "{{ lookup('ansible.builtin.env', 'NESTED_CLUSTER') }}"
 vc_fact_cluster2: "nested-cicluster-2"
-vc_fact_deployment_network: "ci-vlan-981-testing"
-vc_fact_deployment_network2: "ci-vlan-981-testing"
+vc_fact_deployment_network: "{{ lookup('ansible.builtin.env', 'GOVC_NETWORK') }}"
+vc_fact_deployment_network2: ""
 # below is for nested and is the real vCenter to deploy the nested vc to
 vc_hostname: "{{ lookup('ansible.builtin.env', 'MAINVCHOSTNAME') }}"
 vc_username: "{{ lookup('ansible.builtin.env', 'MAINVCUSERNAME') }}"
 vc_password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
-vc_datacenter: "cidatacenter-2"
-vc_cluster: "cicluster-3"
+vc_datacenter: "{{ lookup('ansible.builtin.env', 'GOVC_DATACENTER') }}"
+vc_cluster: "{{ lookup('ansible.builtin.env', 'GOVC_CLUSTER') }}"
 vc_folder: "nested"
 
 # defines tags to be associated with a region, which is a datacenter.
@@ -34,7 +35,7 @@ vc_tag_association:
  -  {
       tag: "us-east",
       object_type: "Datacenter",
-      object_name: "nested-cidatacenter-1"
+      object_name: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
     }
 
 # when defined, each of the tag names will be associated with 
@@ -48,8 +49,8 @@ vc_host_tags:
 # below. a single host will be placed in each host group. The number of
 # hosts and host groups should be same.
 vc_host_groups:
- cluster: nested-cicluster-1
- datacenter: nested-cidatacenter-1
+ cluster: "{{ lookup('ansible.builtin.env', 'NESTED_CLUSTER') }}"
+ datacenter: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
  groups:
   - host-group-1
   - host-group-2

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,6 @@
 vc_fact_domain: "vsphere.local"
 vc_fact_ntp: "10.0.77.54"
-vc_fact_password: "{{ lookup('ansible.builtin.env', 'NESTED_PASSWORD') }}"
+vc_fact_password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
 vc_fact_datacenter1: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
 
 vc_fact_datacenter2: "nested-cidatacenter"
@@ -16,42 +16,5 @@ vc_datacenter: "{{ lookup('ansible.builtin.env', 'GOVC_DATACENTER') }}"
 vc_cluster: "{{ lookup('ansible.builtin.env', 'GOVC_CLUSTER') }}"
 vc_folder: "nested"
 
-# defines tags to be associated with a region, which is a datacenter.
-vc_region_tags:
- - us-east
- - us-west
+###### JOB SPECIFIC VARIABLES WILL BE APPENDED ######
 
-# defines tags to be associated with a zone, which could be a compute
-# cluster or a host.
-vc_zone_tags:
- - us-east-1
- - us-east-2 
- - us-west-1
- - us-west-2
-
-# defines the association of tags to objects in the nested vCenter.
-# named tags and objects must exist. this merely defines the association.
-vc_tag_association:
- -  {
-      tag: "us-east",
-      object_type: "Datacenter",
-      object_name: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
-    }
-
-# when defined, each of the tag names will be associated with 
-# a host. the list of tags is iterated and assigned to a given
-# host. the number of hosts and number of tags should be the same.
-vc_host_tags:
- - us-east-1
- - us-east-2
-
-# when defined, a host group will be created for each host group listed
-# below. a single host will be placed in each host group. The number of
-# hosts and host groups should be same.
-vc_host_groups:
- cluster: "{{ lookup('ansible.builtin.env', 'NESTED_CLUSTER') }}"
- datacenter: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
- groups:
-  - host-group-1
-  - host-group-2
-   

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,21 +1,48 @@
 vc_fact_domain: "vsphere.local"
 vc_fact_ntp: "10.0.77.54"
-vc_fact_password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
-vc_fact_datacenter1: "{{ lookup('ansible.builtin.env', 'NESTED_DATACENTER') }}"
+vc_fact_password: "{{ lookup('ansible.builtin.env', 'NESTED_PASSWORD') }}"
 
-vc_fact_datacenter2: "nested-cidatacenter"
-vc_fact_cluster1: "{{ lookup('ansible.builtin.env', 'NESTED_CLUSTER') }}"
-vc_fact_cluster2: "nested-cicluster-2"
 vc_fact_deployment_network: "{{ lookup('ansible.builtin.env', 'GOVC_NETWORK') }}"
-vc_fact_deployment_network2: ""
+
 # below is for nested and is the real vCenter to deploy the nested vc to
-vc_hostname: "{{ lookup('ansible.builtin.env', 'MAINVCHOSTNAME') }}"
-vc_username: "{{ lookup('ansible.builtin.env', 'MAINVCUSERNAME') }}"
-vc_password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
+vc_hostname: "{{ lookup('ansible.builtin.env', 'GOVC_URL') }}"
+vc_username: "{{ lookup('ansible.builtin.env', 'GOVC_USERNAME') }}"
+vc_password: "{{ lookup('ansible.builtin.env', 'GOVC_PASSWORD') }}"
 vc_datacenter: "{{ lookup('ansible.builtin.env', 'GOVC_DATACENTER') }}"
 vc_datastore: "{{ lookup('ansible.builtin.env', 'GOVC_DATASTORE') }}"
 vc_cluster: "{{ lookup('ansible.builtin.env', 'GOVC_CLUSTER') }}"
 vc_folder: "nested"
+vc_shared_dir: "{{ lookup('ansible.builtin.env', 'SHARED_DIR') }}"
+vc_hosts_per_failure_domain: "{{ lookup('ansible.builtin.env', 'HOSTS_PER_FAILURE_DOMAIN', default=1) }}"
+vc_cluster_name: "{{ lookup('ansible.builtin.env', 'CLUSTER_NAME') }}"
+vc_allocated_memory: "{{ lookup('ansible.builtin.env', 'MEMORY', default=98304) }}"
+vc_allocated_vcpus: "{{ lookup('ansible.builtin.env', 'VCPUS', default=24) }}"
+vc_allocated_disk: "{{ lookup('ansible.builtin.env', 'DISKGB', default=1024) }}"
+vc_skip_tagging: "{{ lookup('ansible.builtin.env', 'SKIP_FAILURE_DOMAIN_TAGGING', default='false') }}"
+vc_vcenter_host_map: {}
 
-###### JOB SPECIFIC VARIABLES WILL BE APPENDED ######
+vc_nfs_shares: 
+- {
+  "server": "161.26.99.159",
+  "name": "dsnested",
+  "path": "/DSW02SEV2284482_22/data01",
+  'type': 'nfs41', 
+  'nfs_ro': 'true'
+}
 
+vc_assets: 
+- {
+  'name': 'VC7.0.3.01400-21477706-ESXi7.0u3q',
+  'esxiova': 'Nested_ESXi7.0u3q_Appliance_Template_v1.ova',
+  'vcenterova': 'VMware-vCenter-Server-Appliance-7.0.3.01400-21477706_OVF10.ova',
+  'httpova': "10.93.245.232:8080"
+}
+- {
+  'name': 'VC8.0.2.00100-22617221-ESXi8.0u2c', 
+  'esxiova': 'Nested_ESXi8.0u2c_Appliance_Template_v1.ova',
+  'vcenterova': 'VMware-vCenter-Server-Appliance-8.0.2.00100-22617221_OVF10.ova',
+  'httpova': "10.93.245.232:8080",
+  'default': "true"
+}
+
+###### ADDITIONAL VARIABLES MAYBE DEFINED OR CHANGED BY DEFINING /tmp/override-vars.yaml ######

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -13,6 +13,7 @@ vc_hostname: "{{ lookup('ansible.builtin.env', 'MAINVCHOSTNAME') }}"
 vc_username: "{{ lookup('ansible.builtin.env', 'MAINVCUSERNAME') }}"
 vc_password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
 vc_datacenter: "{{ lookup('ansible.builtin.env', 'GOVC_DATACENTER') }}"
+vc_datastore: "{{ lookup('ansible.builtin.env', 'GOVC_DATASTORE') }}"
 vc_cluster: "{{ lookup('ansible.builtin.env', 'GOVC_CLUSTER') }}"
 vc_folder: "nested"
 

--- a/host_groups.yml
+++ b/host_groups.yml
@@ -10,7 +10,8 @@
       state: present
     loop: "{{ vc_host_groups.groups }}"
     loop_control:
-      index_var: idx    
+      index_var: my_idx
+    when: vc_host_groups is defined
 
   module_defaults:
     group/vmware:

--- a/host_groups.yml
+++ b/host_groups.yml
@@ -1,21 +1,42 @@
 ---
-- block:
-  - name: "Create DRS Host group"
-    community.vmware.vmware_drs_group:
-      cluster_name: "{{ vc_host_groups.cluster }}"
-      datacenter_name: "{{ vc_host_groups.datacenter }}"
-      group_name: "{{ item }}"
-      hosts:
-      - "{{ hostvars[groups['esxi'][idx]].NESTEDVMIP }}"      
-      state: present
-    loop: "{{ vc_host_groups.groups }}"
-    loop_control:
-      index_var: my_idx
-    when: vc_host_groups is defined
-
+- name: "Configure host groups"
+  vars:
+    host_group_map: {}
   module_defaults:
     group/vmware:
       hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
       username: 'administrator@{{ vc_fact_domain }}'
       password: "{{ vc_fact_password }}"
       validate_certs: false
+  block:
+    - name: "Create DRS Host group variables"
+      vars:
+        affinty_type: "{{ item.zoneAffinity | default('ComputeCluster') }}"
+      ansible.builtin.set_fact:
+        host_group_map: "{{ host_group_map | default({}) | combine({item.name: []}) }}"
+      when: "item.server == vcenter and affinty_type == 'HostGroup'"
+      loop: "{{ vcenter_failure_domains }}"
+
+    - name: "Populate DRS Host group variables"
+      vars:
+        affinty_type: "{{ item.zoneAffinity | default('ComputeCluster') }}"
+      ansible.builtin.set_fact:
+        host_group_map: "{{ host_group_map | default({}) | combine({item.name: host_group_map[item.name] + [hostvars[groups['esxi'][fd_idx]].NESTEDVMIP]}) }}"
+      when: "item.server == vcenter and affinty_type == 'HostGroup'"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
+
+    - name: "Create DRS Host group"
+      vars:
+        affinty_type: "{{ item.zoneAffinity | default('ComputeCluster') }}"
+      community.vmware.vmware_drs_group:
+        cluster_name: '{{ item.topology.computeCluster.split("/")[-1] }}'
+        datacenter_name: "{{ item.topology.datacenter }}"
+        group_name: "{{ item.name }}"
+        hosts: "{{ host_group_map[item.name] }}"
+        state: present
+      when: "item.server == vcenter and affinty_type == 'HostGroup'"
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx

--- a/host_groups.yml
+++ b/host_groups.yml
@@ -1,0 +1,20 @@
+---
+- block:
+  - name: "Create DRS Host group"
+    community.vmware.vmware_drs_group:
+      cluster_name: "{{ vc_host_groups.cluster }}"
+      datacenter_name: "{{ vc_host_groups.datacenter }}"
+      group_name: "{{ item }}"
+      hosts:
+      - "{{ hostvars[groups['esxi'][idx]].NESTEDVMIP }}"      
+      state: present
+    loop: "{{ vc_host_groups.groups }}"
+    loop_control:
+      index_var: idx    
+
+  module_defaults:
+    group/vmware:
+      hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
+      username: 'administrator@{{ vc_fact_domain }}'
+      password: "{{ vc_fact_password }}"
+      validate_certs: false

--- a/main.yml
+++ b/main.yml
@@ -1,99 +1,149 @@
 ---
+- name: Set up configs
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+    - name: Needed packages on system
+      ansible.builtin.include_tasks: packlocal.yml
+      tags:
+        - packlocal
+        - never
 
-- name: Set up hosts
+    - name: Check if /tmp/override-vars.yaml exists
+      ansible.builtin.stat:
+        path: /tmp/override-vars.yaml
+      register: override_file_exists
+
+    - name: Include vars from /tmp/override-vars.yaml
+      ansible.builtin.include_vars:
+        file: /tmp/override-vars.yaml
+      when: override_file_exists.stat.exists
+
+    - name: Resolve installation media
+      ansible.builtin.set_fact:
+        esxiova: "{{ item.esxiova }}"
+        vcenterova: "{{ item.vcenterova }}"
+        httpova: "{{ item.httpova }}"
+      when: 'item.name == version'
+      loop: "{{ vc_assets | list }}"
+
+    - name: Fail if installation media isn't resolved
+      ansible.builtin.fail:
+        msg: "Unable to resolve installation media. Ensure vc_assets is defined."
+      when: httpova is undefined or vcenterova is undefined or esxiova is undefined
+
+- name: Derive topology from platform spec
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  vars:
+    datacenter_cnt: 0
+    host_indexed_failure_domains: []
+
+  tasks:
+    - name: Get platform spec
+      ansible.builtin.slurp:
+        src: "{{ vc_shared_dir }}/nested-ansible-platform.yaml"
+      register: platform_spec_yaml
+
+    - name: Parse platform spec
+      ansible.builtin.set_fact:
+        platform_spec: '{{ platform_spec_yaml.content | b64decode | from_yaml }}'
+
+    - name: Set topology facts
+      ansible.builtin.set_fact:
+        vcenters: '{{ platform_spec.platform.vsphere.vcenters }}'
+        vcenter_cnt: '{{ platform_spec.platform.vsphere.vcenters | length }}'
+        datacenter_cnt: '{{ (datacenter_cnt | int) + (platform_spec.platform.vsphere.vcenters[my_idx].datacenters | length) }}'
+      loop: "{{ platform_spec.platform.vsphere.vcenters | list }}"
+      loop_control:
+        loop_var: loop_bms
+        index_var: my_idx
+
+    - name: Show topology facts
+      ansible.builtin.debug:
+        msg: "***** {{ datacenter_cnt }} datacenters *****"
+
+    # by default, each failure domain gets a single host. the HOSTS_PER_FAILURE_DOMAIN
+    # can be used to set the number of hosts.
+    - name: Update failure domains to account for additional hosts
+      ansible.builtin.set_fact:
+        host_indexed_failure_domains: "{{ host_indexed_failure_domains + platform_spec.platform.vsphere.failureDomains }}"
+      with_sequence: start=1 end="{{ vc_hosts_per_failure_domain }}"
+
+    - name: Initialize ESXi hosts in hostvars
+      ansible.builtin.add_host:
+        name: '{{ vc_cluster_name }}-{{ my_idx + 1 }}'
+        groups: esxi
+        inventory_hostname: '{{ vc_cluster_name }}-{{ my_idx + 1 }}'
+      loop: "{{ host_indexed_failure_domains | list }}"
+      loop_control:
+        loop_var: loop_bms
+        index_var: my_idx
+  tags:
+    - always
+
+- name: Set up nested hosts
   hosts: localhost
   connection: local
   become: false
   gather_facts: false
 
-  tasks:
-
-    - name: Add host to group esxi
-      ansible.builtin.add_host:
-        name: '{{ item }}'
-        groups: esxi
-      loop: '{{ target_hosts | list }}'
-
-    - name: Add host to group vc
-      ansible.builtin.add_host:
-        name: '{{ item }}'
-        groups: vc
-      loop: '{{ target_vcs | list }}'
-
-  tags:
-    - always
-
-- name: Create nested VM's
-  hosts: localhost
-  connection: local
-  gather_facts: true
-  vars:
-    templocation: "{{ ansible_env.HOME }}/build"
-    mountpath: '/data/export/share'
-    version: "7"
-    esximemory: "131072"
-    esxicpu: "20"
-    testingesxi: false
-    testingvc: false
-
-  collections:
-    - community.general
-    - vmware.vmware
-
   module_defaults:
     group/vmware:
-      hostname: "{{ lookup('ansible.builtin.env', 'MAINVCHOSTNAME') }}"
-      username: "{{ lookup('ansible.builtin.env', 'MAINVCUSERNAME') }}"
-      password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
+      hostname: "{{ vc_hostname }}"
+      username: "{{ vc_username }}"
+      password: "{{ vc_password }}"
       validate_certs: false
+  vars:
+    host_count_var: "{{ host_indexed_failure_domains | length }}"
 
   tasks:
+    - name: Provision ESXi VMs
+      ansible.builtin.include_tasks: esxinested.yml
+      loop: "{{ host_indexed_failure_domains | list }}"
+      vars:
+        testingvc: false
+        testingesxi: false
+        esximemory: "{{ ((vc_allocated_memory | int) / (host_count_var | int)) | int }}"
+        esxicpu: "{{ ((vc_allocated_vcpus | int) / (host_count_var | int)) | int }}"
+        esxidisk: "{{ ((vc_allocated_disk | int) / (host_count_var | int)) | int }}"
+      loop_control:
+        loop_var: loop_bms
+        index_var: my_idx
 
-    - name: Set up configs
-      block:
-        - name: Needed packages on system
-          ansible.builtin.include_tasks: packlocal.yml
-      tags:
-        - packlocal
-        - never
+- name: Provision vCenters
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  module_defaults:
+    group/vmware:
+      hostname: "{{ vc_hostname }}"
+      username: "{{ vc_username }}"
+      password: "{{ vc_password }}"
+      validate_certs: false
+  tasks:
+    - name: Provision vCenter VMs
+      ansible.builtin.include_tasks: vcnested.yml
+      loop: "{{ vcenters | list }}"
+      vars:
+        testingvc: false
+      loop_control:
+        loop_var: vcenter
+        index_var: vcenter_idx
 
-    - block:
-        - name: Include vars of vcenter_host-7.yml
-          ansible.builtin.include_vars:
-            file: vcenter_host-7.yml
+    - name: Get CA certificates
+      ansible.builtin.include_tasks: getcerts.yml
+      loop: '{{ groups["vc"] | list }}'
+      loop_control:
+        loop_var: vcenter
+        index_var: vcenter_idx
 
-      when: '"7" in version'
-
-    - block:
-        - name: Include vars of vcenter_host-8.yml
-          ansible.builtin.include_vars:
-            file: vcenter_host-8.yml
-
-      when: '"8" in version'
-
-    - name: Deploy
-      block:
-        - name: Deploy ova of ESXi
-          ansible.builtin.include_tasks: esxinested.yml
-          loop: "{{ groups['esxi'] | list }}"
-          loop_control:
-            loop_var: loop_bms
-            index_var: my_idx
-      tags:
-        - esxinested
-
-    - name: Deploy ova of VC
-      block:
-        - name: Setup VC
-          ansible.builtin.include_tasks: vcnested.yml
-          loop: "{{ groups['vc'] | list }}"
-          loop_control:
-            loop_var: loop_bms_vc
-            index_var: my_idx_vc
-      tags:
-        - vcnested
-
-- name: ESXi add vcenter
+- name: Configure topology
   hosts: localhost
   connection: local
   gather_facts: false
@@ -103,129 +153,42 @@
     nfsetup: true
     nfsiso: false
     localcy: false
-
+    failure_domains: "{{ platform_spec.platform.vsphere.failureDomains }}"
   tags:
     - hostvcenter
 
-  collections:
-    - community.general
-    - community.vmware
-
   tasks:
-
-    - name: Set up vCenter
-      block:
-        - name: Add host to vcenter
-          ansible.builtin.include_tasks: addhosts_vcenter.yml
-          loop: "{{ groups['esxi'] | list }}"
-          loop_control:
-            loop_var: loop_bms
-            index_var: my_idx
-
-        - name: Add dvs to vcenter and add host to dvs
-          ansible.builtin.include_tasks: dvs_hosts_vcenter.yml
-          loop: "{{ groups['esxi'] | list }}"
-          loop_control:
-            loop_var: loop_bms
-            index_var: my_idx
-
-        - name: Create tag categories in nested vCenter
-          include_tasks: tagging.yml
-
-        - name: Assign hosts to host groups
-          include_tasks: host_groups.yml
-          when: vc_host_groups is defined
-      tags:
-        - vcenterhost
-
-- name: REMOVE nested VM's
-  hosts: localhost
-  connection: local
-  gather_facts: true
-  vars:
-    removevsphere: false
-    createcron: false
-    cleanupcron: false
-    showinfo: true
-    getcert: true
-    # installcert: false
-
-  collections:
-    - community.general
-    - community.vmware
-
-  module_defaults:
-    group/vmware:
-      hostname: "{{ lookup('ansible.builtin.env', 'MAINVCHOSTNAME') }}"
-      username: "{{ lookup('ansible.builtin.env', 'MAINVCUSERNAME') }}"
-      password: "{{ lookup('ansible.builtin.env', 'MAINVCPASSWORD') }}"
-      validate_certs: false
-
-  tasks:
-
-    - name: Remove vSphere environment
-      ansible.builtin.include_tasks: vsphere_remove.yml
-      loop: "{{ groups['esxi'] | list }}"
-      loop_control:
-        loop_var: loop_bms
-        index_var: my_idx
-      vars:
-        host_fact_name: "{{ hostvars[groups['esxi'][my_idx]].inventory_hostname }}"
-
-    - name: Remove VC
-      ansible.builtin.include_tasks: vsphere_remove.yml
+    - name: Add host to vcenter
+      ansible.builtin.include_tasks: addhosts_vcenter.yml
       loop: "{{ groups['vc'] | list }}"
       loop_control:
-        loop_var: loop_bms
-        index_var: my_idx
-      vars:
-        host_fact_name: "{{ hostvars[groups['vc'][my_idx]].inventory_hostname }}"
+        loop_var: vcenter
+        index_var: vcenter_idx
 
-    - name: Gather info
-      block:
-        - name: Set cron
-          ansible.builtin.include_tasks: cronjob.yml
-
-        - name: Show vCenter IP
-          ansible.builtin.debug:
-            msg: "***** {{ host_fact_name }} VCENTER IP ADDRESS *****"
-          loop: "{{ groups['vc'] | list }}"
-          loop_control:
-            loop_var: loop_bms
-            index_var: my_idx
-          vars:
-            host_fact_name: "{{ hostvars[groups['vc'][my_idx]]['NESTEDVMIP'] }}"
-
-        - name: Remove file vcenterip
-          ansible.builtin.file:
-            path: /tmp/vcenterip
-            state: absent
-          run_once: true
-
-        - name: Dump vCenter IP to file
-          ansible.builtin.lineinfile:
-            line: "{{ host_fact_name }}"
-            path: /tmp/vcenterip
-            create: yes
-            insertafter: EOF
-          loop: "{{ groups['vc'] | list }}"
-          loop_control:
-            loop_var: loop_bms
-            index_var: my_idx
-          vars:
-            host_fact_name: "{{ hostvars[groups['vc'][my_idx]]['NESTEDVMIP'] }}"
-      when: showinfo | bool
-
-    - name: Certs VC
-      ansible.builtin.include_tasks: getcerts.yml
+    - name: Create DVS for vCenters and attaching hosts
+      ansible.builtin.include_tasks: dvs_hosts_vcenter.yml
       loop: "{{ groups['vc'] | list }}"
       loop_control:
-        loop_var: loop_bms
-        index_var: my_idx
-      vars:
-        host_fact_name: "{{ hostvars[groups['vc'][my_idx]]['NESTEDVMIP'] }}"
-      when: getcert | bool
+        loop_var: vcenter
+        index_var: vcenter_idx
 
+    - name: Create tags and attach to failure domain assets
+      ansible.builtin.include_tasks: tagging.yml
+      loop: "{{ groups['vc'] | list }}"
+      loop_control:
+        loop_var: vcenter
+        index_var: vcenter_idx
+      when: vc_skip_tagging != "true"
 
-  tags:
-    - removevsphere
+    - name: Assign hosts to host groups
+      ansible.builtin.include_tasks: host_groups.yml
+      loop: "{{ groups['vc'] | list }}"
+      loop_control:
+        loop_var: vcenter
+        index_var: vcenter_idx
+
+    - name: Dump inventory
+      ansible.builtin.copy:
+        content: "{{ hostvars | to_json }}"
+        dest: "{{ vc_shared_dir }}/nested-inventory.json"
+        mode: '0644'

--- a/main.yml
+++ b/main.yml
@@ -129,6 +129,11 @@
             loop_var: loop_bms
             index_var: my_idx
 
+        - name: Create tag categories in nested vCenter
+          include_tasks: tagging.yml
+
+        - name: Assign hosts to host groups
+          include_tasks: host_groups.yml
       tags:
         - vcenterhost
 

--- a/main.yml
+++ b/main.yml
@@ -134,6 +134,7 @@
 
         - name: Assign hosts to host groups
           include_tasks: host_groups.yml
+          when: vc_host_groups is defined
       tags:
         - vcenterhost
 

--- a/platform.example.yaml
+++ b/platform.example.yaml
@@ -1,0 +1,33 @@
+platform:
+  vsphere:
+    vcenters:
+      - server: vcenter-1
+        user: "administrator@vsphere.local"
+        password: "${vcenter_password}"
+        datacenters:
+        - cidatacenter-nested-0
+        - cidatacenter-nested-1
+    failureDomains:
+      - server: vcenter-1
+        name: "cidatacenter-nested-0-cicluster-nested-0"
+        zone: "cidatacenter-nested-0-cicluster-nested-0"
+        region: cidatacenter-nested-0
+        topology:
+          resourcePool: /cidatacenter-nested-0/host/cicluster-nested-0/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-0/host/cicluster-nested-0
+          datacenter: cidatacenter-nested-0
+          datastore: /cidatacenter-nested-0/datastore/dsnested
+          networks:
+            - "VM Network"
+      - server: vcenter-1
+        name: "cidatacenter-nested-1-cicluster-nested-3"
+        zone: "cidatacenter-nested-1-cicluster-nested-3"
+        region: cidatacenter-nested-1
+        zoneAffinity: "HostGroup"
+        topology:        
+          resourcePool: /cidatacenter-nested-1/host/cicluster-nested-3/Resources/ipi-ci-clusters
+          computeCluster: /cidatacenter-nested-1/host/cicluster-nested-3
+          datacenter: cidatacenter-nested-1
+          datastore: /cidatacenter-nested-1/datastore/dsnested
+          networks:
+            - "VM Network"

--- a/run-from-job.sh
+++ b/run-from-job.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+export VCESXIPASSWORD="${vcenter_password}"
+export MAINVCPASSWORD="${vcenter_password}"
+export MAINVCUSERNAME="${vcenter_username}"
+export MAINVCHOSTNAME="${vcenter_password}"
+
+joinByChar() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+export NAMESPACE=${NAMESPACE:-ci-op-test}
+export HOST_COUNT=${HOST_COUNT:-1}
+export VCPUS=${VCPUS:-24}
+export MEMORY=${MEMORY:-96}
+
+export VCPUS_PER_HOST=$((VCPUS / HOST_COUNT))
+export MEMORY_PER_HOST=$(((MEMORY / HOST_COUNT) * 1024))
+
+HOSTS=()
+
+for ((i=1; i<=HOST_COUNT; i++)); do
+    HOSTS+=("$NAMESPACE-host-$i")
+done
+
+TARGET_HOSTS=$(joinByChar , "${HOSTS[@]}")
+VCENTER_NAME="$NAMESPACE-vcenter"
+
+ansible-playbook -i hosts main.yml --extra-var version="8" --extra-var='{"target_hosts": ['$TARGET_HOSTS']}' --extra-var='{"target_vcs": ['$VCENTER_NAME']}' --extra-var esximemory="${MEMORY_PER_HOST}" --extra-var esxicpu="${VCPUS_PER_HOST}"

--- a/tagging.yml
+++ b/tagging.yml
@@ -1,51 +1,103 @@
 ---
-- block:
-  - name: Create a zone tag category in nested vCenter
-    community.vmware.vmware_category:
-      validate_certs: no
-      category_name: "openshift-zone"
-      category_description: "Zone tags"
-      category_cardinality: "single"
-      associable_object_types:
-        - "Host"
-        - "Cluster"
+- name: Configure topology
+  run_once: true
+  vars:
+    vcenter_failure_domains: []
+    affinity_tag_type_map: {
+      "Datacenter": "Datacenter",
+      "ComputeCluster": "ClusterComputeResource",
+      "HostGroup": "HostSystem"
+    }
+  block:
+    - name: Get failure domains associated with the vCenter
+      ansible.builtin.set_fact:
+        vcenter_failure_domains: "{{ vcenter_failure_domains + [item] }}"
+      when: "item.server == vcenter"
+      loop: "{{ failure_domains }}"
 
-  - name: Create a region tag category in nested vCenter
-    community.vmware.vmware_category:
-      validate_certs: no
-      category_name: "openshift-region"
-      category_description: "Region tags"
-      category_cardinality: "single"
-      associable_object_types:
-        - "Datacenter"
-  
-  - name: Create region tags
-    community.vmware.vmware_tag:
-      category_name: "openshift-region"
-      tag_name: "{{ item }}"
-    loop: "{{ vc_region_tags }}"
+    - name: Create a zone tag category in nested vCenter
+      community.vmware.vmware_category:
+        validate_certs: no
+        category_name: "openshift-zone"
+        category_description: "Zone tags"
+        category_cardinality: "single"
+        associable_object_types:
+          - "Host"
+          - "Cluster"
 
-  - name: Create zone tags
-    community.vmware.vmware_tag:
-      category_name: "openshift-zone"
-      tag_name: "{{ item }}"
-    loop: "{{ vc_zone_tags }}"
+    - name: Create a region tag category in nested vCenter
+      community.vmware.vmware_category:
+        validate_certs: no
+        category_name: "openshift-region"
+        category_description: "Region tags"
+        category_cardinality: "single"
+        associable_object_types:
+          - "Datacenter"
 
-  - name: Assign topology tags
-    community.vmware.vmware_tag_manager:
-      object_name: "{{ item.object_name }}"
-      object_type: "{{ item.object_type }}"
-      tag_names: 
-      - "{{ item.tag }}"
-    loop: "{{ vc_tag_association }}"
-    retries: 30
-    delay: 60
-    register: result
-    until: result is succeeded    
+    - name: Create region tags
+      community.vmware.vmware_tag:
+        category_name: "openshift-region"
+        tag_name: "{{ item.region }}"
+      loop: "{{ vcenter_failure_domains }}"
+
+    - name: Create zone tags
+      community.vmware.vmware_tag:
+        category_name: "openshift-zone"
+        tag_name: "{{ item.zone }}"
+      loop: "{{ vcenter_failure_domains }}"
+
+    - name: Attach Region Tags
+      vars:
+        affinty_type: "{{ item.regionAffinity | default('Datacenter') }}"
+        resourceName: '{{ {"Datacenter": item.topology.datacenter, "ComputeCluster": item.topology.computeCluster.split("/")[-1]} }}'
+      community.vmware.vmware_tag_manager:
+        object_name: "{{ resourceName[affinty_type] }}"
+        object_type: "{{ affinity_tag_type_map[affinty_type] }}"
+        tag_names:
+          - "{{ item.region }}"
+      loop: "{{ vcenter_failure_domains }}"
+      retries: 30
+      delay: 60
+      when: resourceName != "" and item.region is not match("^-")
+      register: result
+      until: result is succeeded
+
+    - name: Attach Zone Tags
+      vars:
+        affinty_type: "{{ item.zoneAffinity | default('ComputeCluster') }}"
+        resourceName: '{{ {"Datacenter": item.topology.datacenter, "ComputeCluster": item.topology.computeCluster.split("/")[-1]} }}'
+      community.vmware.vmware_tag_manager:
+        object_name: "{{ resourceName[affinty_type] }}"
+        object_type: "{{ affinity_tag_type_map[affinty_type] }}"
+        tag_names:
+          - "{{ item.zone }}"
+      loop: "{{ vcenter_failure_domains }}"
+      retries: 30
+      delay: 60
+      when: affinty_type != 'HostGroup' and item.zone is not match("^-")
+      register: result
+      until: result is succeeded
+
+    - name: Attach host tags
+      vars:
+        affinty_type: "{{ item.zoneAffinity | default('') }}"
+      community.vmware.vmware_tag_manager:
+        object_name: "{{ hostvars[groups['esxi'][fd_idx]].NESTEDVMIP }}"
+        object_type: "HostSystem"
+        tag_names:
+          - "{{ item.zone }}"
+      when: item.server == vcenter and affinty_type == 'HostGroup' and item.zone is not match("^-")
+      loop: "{{ host_indexed_failure_domains }}"
+      loop_control:
+        index_var: fd_idx
+      retries: 30
+      delay: 60
+      register: result
+      until: result is succeeded
 
   module_defaults:
     group/vmware:
-      hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
+      hostname: "{{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
       username: 'administrator@{{ vc_fact_domain }}'
       password: "{{ vc_fact_password }}"
       validate_certs: false

--- a/tagging.yml
+++ b/tagging.yml
@@ -38,6 +38,10 @@
       tag_names: 
       - "{{ item.tag }}"
     loop: "{{ vc_tag_association }}"
+    retries: 30
+    delay: 60
+    register: result
+    until: result is succeeded    
 
   module_defaults:
     group/vmware:

--- a/tagging.yml
+++ b/tagging.yml
@@ -31,23 +31,13 @@
       tag_name: "{{ item }}"
     loop: "{{ vc_zone_tags }}"
 
-  - name: Assign region tags
+  - name: Assign topology tags
     community.vmware.vmware_tag_manager:
       object_name: "{{ item.object_name }}"
       object_type: "{{ item.object_type }}"
       tag_names: 
       - "{{ item.tag }}"
     loop: "{{ vc_tag_association }}"
-
-  - name: Assign host tags
-    community.vmware.vmware_tag_manager:
-      object_name: "{{ hostvars[groups['esxi'][idx]].NESTEDVMIP }}"
-      object_type: "HostSystem"
-      tag_names: 
-      - "{{ item }}"
-    loop: "{{ vc_host_tags }}"
-    loop_control:
-      index_var: idx
 
   module_defaults:
     group/vmware:

--- a/tagging.yml
+++ b/tagging.yml
@@ -1,0 +1,57 @@
+---
+- block:
+  - name: Create a zone tag category in nested vCenter
+    community.vmware.vmware_category:
+      validate_certs: no
+      category_name: "openshift-zone"
+      category_description: "Zone tags"
+      category_cardinality: "single"
+      associable_object_types:
+        - "Host"
+        - "Cluster"
+
+  - name: Create a region tag category in nested vCenter
+    community.vmware.vmware_category:
+      validate_certs: no
+      category_name: "openshift-region"
+      category_description: "Region tags"
+      category_cardinality: "single"
+      associable_object_types:
+        - "Datacenter"
+  
+  - name: Create region tags
+    community.vmware.vmware_tag:
+      category_name: "openshift-region"
+      tag_name: "{{ item }}"
+    loop: "{{ vc_region_tags }}"
+
+  - name: Create zone tags
+    community.vmware.vmware_tag:
+      category_name: "openshift-zone"
+      tag_name: "{{ item }}"
+    loop: "{{ vc_zone_tags }}"
+
+  - name: Assign region tags
+    community.vmware.vmware_tag_manager:
+      object_name: "{{ item.object_name }}"
+      object_type: "{{ item.object_type }}"
+      tag_names: 
+      - "{{ item.tag }}"
+    loop: "{{ vc_tag_association }}"
+
+  - name: Assign host tags
+    community.vmware.vmware_tag_manager:
+      object_name: "{{ hostvars[groups['esxi'][idx]].NESTEDVMIP }}"
+      object_type: "HostSystem"
+      tag_names: 
+      - "{{ item }}"
+    loop: "{{ vc_host_tags }}"
+    loop_control:
+      index_var: idx
+
+  module_defaults:
+    group/vmware:
+      hostname: "{{ hostvars[groups['vc'][0]].NESTEDVMIP }}"
+      username: 'administrator@{{ vc_fact_domain }}'
+      password: "{{ vc_fact_password }}"
+      validate_certs: false

--- a/vcenter_host-7.yml
+++ b/vcenter_host-7.yml
@@ -1,3 +1,0 @@
-esxiova: 'Nested_ESXi7.0u3q_Appliance_Template_v1.ova'
-vcenterova: 'VMware-vCenter-Server-Appliance-7.0.3.01400-21477706_OVF10.ova'
-httpova: "10.93.245.232:8080"

--- a/vcenter_host-8.yml
+++ b/vcenter_host-8.yml
@@ -1,3 +1,0 @@
-esxiova: 'Nested_ESXi8.0u2c_Appliance_Template_v1.ova'
-vcenterova: 'VMware-vCenter-Server-Appliance-8.0.2.00100-22617221_OVF10.ova'
-httpova: "10.93.245.232:8080"

--- a/vcnested.yml
+++ b/vcnested.yml
@@ -80,7 +80,7 @@
         name: '{{ host_fact_hostname }}'
         enable_hidden_properties: true
         folder: "{{ vc_datacenter }}/vm/{{ vc_folder }}"
-        datastore: vsanDatastore
+        datastore: "{{ vc_datastore }}"
         disk_provisioning: thin
         networks:
           "Network 1": "{{ vc_fact_deployment_network }}"

--- a/vcnested.yml
+++ b/vcnested.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: List hosts in ESXi
   ansible.builtin.debug:
     msg: "Host: {{ item }}"
@@ -7,12 +6,12 @@
 
 - name: List hosts in VC
   ansible.builtin.debug:
-    msg: "Host: {{ item }}"
-  loop: "{{ groups['vc'] }}"
+    msg: "Host: {{ item.server }}"
+  loop: "{{ vcenters }}"
 
 - name: Set vc name
   ansible.builtin.set_fact:
-    host_fact_hostname: "{{ hostvars[groups['vc'][my_idx_vc]].inventory_hostname }}"
+    host_fact_hostname: "{{ vcenter.server }}"
 
 - name: Setting host facts
   ansible.builtin.set_fact:
@@ -26,7 +25,6 @@
 
 - name: VC Exists
   block:
-
     - name: "DELETE virtual machine {{ host_fact_hostname }} version {{ version }}"
       community.vmware.vmware_guest:
         datacenter: "{{ vc_datacenter }}"
@@ -97,8 +95,6 @@
           guestinfo.cis.appliance.ssh.enabled: 'True'
           guestinfo.cis.deployment.autoconfig: 'True' # Auto-configure after deployment
           guestinfo.cis.appliance.root.shell: 'True'
-#          guestinfo.cis.appliance.net.pnid: 'localhost'
-#          guestinfo.cis.appliance.net.dns.servers: '10.10.10.10'
       register: nested_vm
 
     - name: Pause while reboots itself
@@ -135,7 +131,7 @@
 
     - name: Wait for vCenter
       vmware_about_info:
-        hostname: "{{ hostvars[groups['vc'][my_idx_vc]].NESTEDVMIP }}"
+        hostname: "{{ hostvars[groups['vc'][vcenter_idx]].NESTEDVMIP }}"
         username: 'administrator@{{ vc_fact_domain }}'
         password: "{{ vc_fact_password }}"
         validate_certs: false
@@ -144,7 +140,7 @@
       register: result
       until: result is succeeded
 
-    - name: "Wait for {{ hostvars[groups['vc'][my_idx_vc]].inventory_hostname }} {{ nested_vm.instance.guest.ipAddress }} install of VC on host to be complete"
+    - name: "Wait for {{ hostvars[groups['vc'][vcenter_idx]].inventory_hostname }} {{ nested_vm.instance.guest.ipAddress }} install of VC on host to be complete"
       ansible.builtin.wait_for:
         host: "{{ nested_vm.instance.guest.ipAddress }}"
         port: 443


### PR DESCRIPTION
**Changes**

- Updated to use vSphere topology in the openshift/api to define the nested topology
- Updated README with details and samples
- Made vCenter/ESXi assets a list so we can add support for new assets without changing ansible
- Implemented tagging, host groups, multiple dataceenter, multiple vCenters
- Made NFS mounts a list so we can add support for new shares without changing ansible
