### PR TITLE
configure a sane CPU topology and use hw version 21

### DIFF
--- a/esxinested.yml
+++ b/esxinested.yml
@@ -86,7 +86,9 @@
         hardware:
           memory_mb: "{{ esximemory }}"
           num_cpus: "{{ esxicpu }}"
+          num_cpu_cores_per_socket: "{{ esxicpu }}"
           nested_virt: true
+          version: 21
 
 - name: "Does ESXi virtual machine {{ host_fact_hostname }} exist"
   community.vmware.vmware_guest:


### PR DESCRIPTION
ESXi hosts are being configured with multiple sockets rather than multiple cores per socket.  Additionally, the hw version needs be hw21 to enable NUMA optimizations.